### PR TITLE
rearranged large/small order

### DIFF
--- a/Data/BlockVariantGroups.sbc
+++ b/Data/BlockVariantGroups.sbc
@@ -8,14 +8,14 @@
 			<DisplayName>DisplayName_Block_OreDetector</DisplayName>
 			<Description>Description_OreDetector</Description>
 			<Blocks>
-				<Block Type="MyObjectBuilder_OreDetector" Subtype="SmallBlockOreDetector" />
-				<Block Type="MyObjectBuilder_OreDetector" Subtype="SmallBlockMediumOreDetector" />
-				<Block Type="MyObjectBuilder_OreDetector" Subtype="SmallBlockLargeOreDetector" />
-				<Block Type="MyObjectBuilder_OreDetector" Subtype="SmallBlockMassiveOreDetector" />
 				<Block Type="MyObjectBuilder_OreDetector" Subtype="LargeOreDetector" />
 				<Block Type="MyObjectBuilder_OreDetector" Subtype="LargeBlockMediumOreDetector" />
 				<Block Type="MyObjectBuilder_OreDetector" Subtype="LargeBlockLargeOreDetector" />
 				<Block Type="MyObjectBuilder_OreDetector" Subtype="LargeBlockMassiveOreDetector" />
+				<Block Type="MyObjectBuilder_OreDetector" Subtype="SmallBlockOreDetector" />
+				<Block Type="MyObjectBuilder_OreDetector" Subtype="SmallBlockMediumOreDetector" />
+				<Block Type="MyObjectBuilder_OreDetector" Subtype="SmallBlockLargeOreDetector" />
+				<Block Type="MyObjectBuilder_OreDetector" Subtype="SmallBlockMassiveOreDetector" />
 			</Blocks>
 		</BlockVariantGroup>
 		

--- a/Data/CubeBlocks.sbc
+++ b/Data/CubeBlocks.sbc
@@ -417,7 +417,7 @@ This one has double the range of the previous, taking an extreme amount of CPU.<
 	
 	<BlockPositions>
 		<BlockPosition>
-			<Name>SmallOreDetector</Name>
+			<Name>LargeOreDetector</Name>
 			<Position>
 				<X>3</X>
 				<Y>5</Y>


### PR DESCRIPTION
put large block first in blockvariants, now shows on gmenu, and changed blockpositions block to largeoredetector